### PR TITLE
Internal: add checks for changelog fragments, new changelog fragment type

### DIFF
--- a/.changes/unreleased/Internal-20240928-132001.yaml
+++ b/.changes/unreleased/Internal-20240928-132001.yaml
@@ -1,0 +1,5 @@
+kind: Internal
+body: Add GitHub action to check that all PRs introduce a CHANGELOG fragement
+time: 2024-09-28T13:20:01.213543-07:00
+custom:
+  Author: Ryan Ozawa

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -15,6 +15,8 @@ kinds:
     auto: major
   - label: Fixed
     auto: patch
+  - label: Internal
+    auto: none
 newlines:
   afterChange: 0
   afterChangelogHeader: 0

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,27 @@
+name: Check File Changes
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+jobs:
+  check-file-changes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Diff Files
+        run: |
+            if [[ -z $(git diff --name-only origin/main .changes) ]]; then
+              echo "No changes detected. Failing the action."
+              exit 1
+            fi


### PR DESCRIPTION
# Overview

In order to keep our changes tracked outside of just GIT history, enforce that all changes via PR must include a Changelog fragment from [changie](https://changie.dev).

## Individual Changes

- **[github action] add: check that PRs add a changelog entry**
- **[changelog] add: label for repository changes**
