### PR TITLE
Remove unnecessary xfail markers

### DIFF
--- a/.changes/unreleased/Internal-20240929-125259.yaml
+++ b/.changes/unreleased/Internal-20240929-125259.yaml
@@ -1,0 +1,5 @@
+kind: Internal
+body: Add arguments for vscode test tab to no display coverage information
+time: 2024-09-29T12:52:59.324888-07:00
+custom:
+  Author: rhyn0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,10 @@
     "mypy-type-checker.path": [
         "${workspaceFolder}/.venv/bin/mypy",
     ],
+    "python.testing.pytestArgs": [
+        "--config-file=pyproject.toml",
+        "--no-cov",
+    ],
     "[python]": {
         "diffEditor.ignoreTrimWhitespace": false,
         "gitlens.codeLens.symbolScopes": [

--- a/tests/application/test_start.py
+++ b/tests/application/test_start.py
@@ -5,7 +5,6 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 
-@pytest.mark.xfail
 class TestStartupEvents:
     """Collection of tests dealing with startup events."""
 
@@ -18,7 +17,6 @@ class TestStartupEvents:
             assert "anime-api" in loggers
 
 
-@pytest.mark.xfail
 class TestDatabase:
     """Tests regarding startup behavior with database."""
 


### PR DESCRIPTION
- **change: remove xfail marker on passing tests**
- **change: limit coverage information inside vscode test run**
